### PR TITLE
correct previous edition links in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -148,7 +148,7 @@
     </p>
 
     <p>
-      Previous editions of our workshop: <a href="https://nips.cc/Conferences/2020/ScheduleMultitrack?event=16146">2020</a>, <a href="https://sslneuips21.github.io/">2021</a>, <a href="https://sslneuips22.github.io/">2022</a>, <a href="https://sslneuips23.github.io/">2023</a>.
+      Previous editions of our workshop: <a href="https://nips.cc/Conferences/2020/ScheduleMultitrack?event=16146">2020</a>, <a href="https://sslneurips21.github.io/">2021</a>, <a href="https://sslneurips22.github.io/">2022</a>, <a href="https://sslneurips23.github.io/">2023</a>.
     </p>
 
     


### PR DESCRIPTION
Was searching for previous editions for neurips workshops, links were not working. So I corrected the links typo as I found them